### PR TITLE
Change API behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,23 +82,30 @@ Currently, you can configure settings:
 ## API
 Base API URL: `http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
 
-This API returns light state in JSON: `{state: true}` <br />
-A GET API call will require a API key with the "STATUS" permission.  Without this, you will receive a 403 error.
-
-A POST API call will require a API key with the "PLUGIN_OCTOLIGHT_CONTROL" permission.  Without this, you will receive a 403 error.
+This API returns light state in JSON for both GET and POST requests: `{state: true}` <br />
+A GET API call will require a API key with the "STATUS" permission.  Without this, you will receive a 403 error. <br />
+A POST API call will require a API key with the "CONTROL" permission.  Without this, you will receive a 403 error.
 
 #### Actions
 - **toggle**: Toggle light switch on/off.
 - **turnOn**: Turn on light.
 - **turnOff**: Turn off light.
-- **delayOff**: Turn on light and setup timer to shutoff light after delay time, note, `{ "delay": VALUE }` should be added to the body.
-- **delayOffStop**: Testing for shutting off timer and light.
+- **delayOff**: Turn on light and setup timer to shutoff light after delay time, note, `{ "delay": VALUE }` can be added to the body to override the default delay time.
+- **delayOffStop**: Shuts off timer and light.
 
 #### Examples
 
-Toggle light: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "toggle"}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+##### GET Request
+- Check the light status: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
 
-Delay off after 3 min: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "delayOff", "delay": 3}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+##### POST Requests
+- Toggle light: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "toggle"}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+- Turn light on: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "turnOn"}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+- Turn light off: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "turnOff"}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+- Delay off with default value: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "delayOff"}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+- Delay off after 3 min: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "delayOff", "delay": 3}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+- Delay off stop: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "delayOffStop"}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+
 
 ## Thank you list
 Thank you goes out to the following people:

--- a/README.md
+++ b/README.md
@@ -80,11 +80,14 @@ Currently, you can configure settings:
 
 
 ## API
+
+**Note:** As of version 1.0.1, the API has been updated to be more in line with a RESTFUL standard, instead of functions being changed with a ``GET`` request, the new setup requires a ``POST`` request and the command to be sent in the body.  To keep backwards compatibility with previous API calls, the previous ``GET`` commands can still be used, however, it is recommended to update as these commands will be removed around the end of 2024.  Please reach out if this is an issue or if you need help.  Please have a look at the new API calls below to update.
+
 Base API URL: `http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
 
-This API returns light state in JSON for both GET and POST requests: `{state: true}` <br />
-A GET API call will require a API key with the "STATUS" permission.  Without this, you will receive a 403 error. <br />
-A POST API call will require a API key with the "CONTROL" permission.  Without this, you will receive a 403 error.
+This API returns light state in JSON for both ``GET`` and ``POST`` requests: ``{state: true}`` <br />
+- ``GET`` calls will require a API key with the "STATUS" permission.  Without this, you will receive a 403 error. <br />
+- ``POST`` calls will require a API key with the "CONTROL" permission.  Without this, you will receive a 403 error.
 
 #### Actions
 - **toggle**: Toggle light switch on/off.

--- a/README.md
+++ b/README.md
@@ -80,21 +80,25 @@ Currently, you can configure settings:
 
 
 ## API
-Base API URL: `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=ACTION_NAME`
+Base API URL: `http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
 
-This API always returns updated light state in JSON: `{state: true}` <br />
-Any API call will require a API key with the "Control" permission.  Without this, you will receive a 403 error.
+This API returns light state in JSON: `{state: true}` <br />
+A GET API call will require a API key with the "STATUS" permission.  Without this, you will receive a 403 error.
 
-_(if the action parameter not given, the action toggle will be used by default)_
+A POST API call will require a API key with the "PLUGIN_OCTOLIGHT_CONTROL" permission.  Without this, you will receive a 403 error.
+
 #### Actions
-- **toggle** (default action): Toggle light switch on/off.
+- **toggle**: Toggle light switch on/off.
 - **turnOn**: Turn on light.
 - **turnOff**: Turn off light.
-- **getState**: Get current light switch state.
-- **delayOff**: Turn on light and setup timer to shutoff light after delay time, note, `&delay=VALUE` can be added to the URL to override the default time value.
+- **delayOff**: Turn on light and setup timer to shutoff light after delay time, note, `{ "delay": VALUE }` should be added to the body.
 - **delayOffStop**: Testing for shutting off timer and light.
 
+#### Examples
 
+Toggle light: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "toggle"}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
+
+Delay off after 3 min: `curl -H "Content-Type: application/json" -H "X-Api-Key: YOUR_OCTOPRINT_API_KEY" -X POST -d '{"command": "delayOff", "delay": 3}' http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight`
 
 ## Thank you list
 Thank you goes out to the following people:

--- a/octoprint_octolight/__init__.py
+++ b/octoprint_octolight/__init__.py
@@ -246,7 +246,7 @@ class OctoLightPlugin(
 
 
 	# Handle GET requests, return the state of the light
-	@Permissions.STATUS.require(403)
+	@Permissions.PLUGIN_OCTOLIGHT_STATUS.require(403)
 	def on_api_get(self, request):
 		#-------------------
 		# Old actions these will be removed in the future and should not be used.
@@ -283,7 +283,7 @@ class OctoLightPlugin(
 
 	# Handles POST commands, this is used to handle the changing of the lights state
 	# based on the command issued
-	@Permissions.CONTROL.require(403)
+	@Permissions.PLUGIN_OCTOLIGHT_CONTROL.require(403)
 	def on_api_command(self, command, data):
 		if command == "toggle":
 			self.light_toggle()

--- a/octoprint_octolight/__init__.py
+++ b/octoprint_octolight/__init__.py
@@ -221,7 +221,7 @@ class OctoLightPlugin(
 		# Handles a toggle on and off as a button press
 		if self.toggle_output:
 			GPIO.output(self.light_pin, GPIO.HIGH)
-			self.delayed_toggle = RepeatedTimer(self.toggle_delay / 1000, self.light_button_toggle)
+			self.delayed_toggle=RepeatedTimer(self.toggle_delay / 1000, self.light_button_toggle)
 			self.delayed_toggle.start()
 		# Sets the light state depending on the inverted output setting (XOR)
 		elif self.light_state ^ self.inverted_output:
@@ -229,7 +229,7 @@ class OctoLightPlugin(
 		else:
 			GPIO.output(self.light_pin, GPIO.LOW)
 
-		self._logger.debug ("Got request. Light state: {}".format(self.light_state))
+		self._logger.debug("Got request. Light state: {}".format(self.light_state))
 
 		self._plugin_manager.send_plugin_message(
 			self._identifier, dict(isLightOn=self.light_state)
@@ -244,20 +244,46 @@ class OctoLightPlugin(
 		if self.light_state:
 			self.light_toggle()
 
+
+	# Handle GET requests, return the state of the light
+	@Permissions.STATUS.require(403)
+	def on_api_get(self, request):
+		#-------------------
+		# Old actions these will be removed in the future and should not be used.
+		action = request.args.get("action", default="", type=str)
+		delay = request.args.get("delay", default=self.delayed_off_time, type=int)
+
+		if action != "":
+			self._logger.warning("OctoLight API GET calls to change the light are soon to be removed, please change to the updated POST API calls")
+
+		if action == "toggle":
+			self.light_toggle()
+		elif action == "turnOn":
+			self.light_on()
+		elif action == "turnOff":
+			self.light_off()
+		elif action == "delayOff":
+			self.delayed_off_setup(delay)
+		elif action == "delayOffStop":
+			self.delayed_off()
+		# End of old actions
+		#-------------------
+
+		return flask.jsonify(state=self.light_state)
+
+	# Setups up required commands and data for POST request
 	def get_api_commands(self):
 		return dict(
 			toggle=[],
 			turnOn=[],
 			turnOff=[],
-			delayOff=["delay"],
+			delayOff=[],	# "delay" is an optional value to send and must be a number greater then 0
 			delayOffStop=[]
 			)
 
-	@Permissions.STATUS.require(403)
-	def on_api_get(self, request):
-		return flask.jsonify(state=self.light_state)
-
-	@Permissions.PLUGIN_OCTOLIGHT_CONTROL.require(403)
+	# Handles POST commands, this is used to handle the changing of the lights state
+	# based on the command issued
+	@Permissions.CONTROL.require(403)
 	def on_api_command(self, command, data):
 		if command == "toggle":
 			self.light_toggle()
@@ -268,10 +294,20 @@ class OctoLightPlugin(
 		#Turn on light and setup timer
 		elif command == "delayOff":
 			if "delay" in data:
+				if not isinstance(data["delay"], int):
+					return flask.make_response("Bad delay value", 400)
+				elif data["delay"] < 0:
+					return flask.make_response("Bad delay value", 400)
 				self.delayed_off_setup(data["delay"])
+			else:
+				self.delayed_off_setup(self.delayed_off_time)
 		#Turn off off timer and light
 		elif command == "delayOffStop":
 			self.delayed_off()
+		else:
+			return flask.make_response("Unknown command", 400)
+		return flask.jsonify(state=self.light_state)
+	
 
 	#This stops the current timer, this does not control the light
 	def stopTimer(self):
@@ -390,6 +426,12 @@ class OctoLightPlugin(
 				dict(key="CONTROL",
 					name="Control",
 					description=gettext("Allows switching relays on/off"),
+					roles=["admin"],
+					dangerous=True,
+					default_groups=[Permissions.ADMIN_GROUP]),
+				dict(key="STATUS",
+					name="Status",
+					description=gettext("Allows the viewing of Light status"),
 					roles=["admin"],
 					dangerous=True,
 					default_groups=[Permissions.ADMIN_GROUP])

--- a/octoprint_octolight/__init__.py
+++ b/octoprint_octolight/__init__.py
@@ -244,40 +244,34 @@ class OctoLightPlugin(
 		if self.light_state:
 			self.light_toggle()
 
+	def get_api_commands(self):
+		return dict(
+			toggle=[],
+			turnOn=[],
+			turnOff=[],
+			delayOff=["delay"],
+			delayOffStop=[]
+			)
 
-	@Permissions.CONTROL.require(403)
+	@Permissions.STATUS.require(403)
 	def on_api_get(self, request):
-		action = request.args.get("action", default="toggle", type=str)
-		delay = request.args.get("delay", default=self.delayed_off_time, type=int)
+		return flask.jsonify(state=self.light_state)
 
-		if action == "toggle":
+	@Permissions.PLUGIN_OCTOLIGHT_CONTROL.require(403)
+	def on_api_command(self, command, data):
+		if command == "toggle":
 			self.light_toggle()
-
-			return flask.jsonify(state=self.light_state)
-
-		elif action == "getState":
-			return flask.jsonify(state=self.light_state)
-
-		elif action == "turnOn":
+		elif command == "turnOn":
 			self.light_on()
-			return flask.jsonify(state=self.light_state)
-
-		elif action == "turnOff":
+		elif command == "turnOff":
 			self.light_off()
-			return flask.jsonify(state=self.light_state)
-
 		#Turn on light and setup timer
-		elif action == "delayOff":
-			self.delayed_off_setup(delay)
-			return flask.jsonify(state=self.light_state)
-
+		elif command == "delayOff":
+			if "delay" in data:
+				self.delayed_off_setup(data["delay"])
 		#Turn off off timer and light
-		elif action == "delayOffStop":
+		elif command == "delayOffStop":
 			self.delayed_off()
-			return flask.jsonify(state=self.light_state)
-
-		else:
-			return flask.jsonify(error="action not recognized")
 
 	#This stops the current timer, this does not control the light
 	def stopTimer(self):

--- a/octoprint_octolight/static/js/octolight.js
+++ b/octoprint_octolight/static/js/octolight.js
@@ -30,16 +30,8 @@ $(function () {
             });
         };
 
-        self.light_toggle = function() {
-           $.ajax({
-                url: API_BASEURL + "plugin/octolight",
-                type: "POST",
-                dataType: "json",
-                data: JSON.stringify({
-                    command: "toggle"
-                }),
-                contentType: "application/json; charset=UTF-8"
-            })
+        self.light_toggle = function () {
+            OctoPrint.simpleApiCommand("octolight", "toggle").done();
         };
     }
 

--- a/octoprint_octolight/static/js/octolight.js
+++ b/octoprint_octolight/static/js/octolight.js
@@ -28,7 +28,19 @@ $(function () {
                     self.light_indicator.removeClass("on").addClass("off");
                 }
             });
-        }
+        };
+
+        self.light_toggle = function() {
+           $.ajax({
+                url: API_BASEURL + "plugin/octolight",
+                type: "POST",
+                dataType: "json",
+                data: JSON.stringify({
+                    command: "toggle"
+                }),
+                contentType: "application/json; charset=UTF-8"
+            })
+        };
     }
 
     OCTOPRINT_VIEWMODELS.push({

--- a/octoprint_octolight/templates/octolight_navbar.jinja2
+++ b/octoprint_octolight/templates/octolight_navbar.jinja2
@@ -1,1 +1,1 @@
-<a id="light_indicator" class="off" onclick='OctoPrint.simpleApiGet("octolight")' style="font-size: 1.3em; text-shadow: 0px 0px 2px #000; cursor: pointer; user-select: none">&#x1F4A1;</a>
+<a id="light_indicator" class="off" title="OctoLight" data-bind="click: function() { loginState.isUser() && $root.light_toggle(); }" style="font-size: 1.3em; text-shadow: 0px 0px 2px #000; cursor: pointer; user-select: none">&#x1F4A1;</a>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octolight"
 plugin_name = "OctoLight"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.0"
+plugin_version = "1.0.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
All the API calls are using the GET method, even the calls that preform actions.
This change divide the API in GET and POST commands, for better implementation in other software.

Tested in OctoPrint 1.10.2 + python 3.9.2 + OctoPi 1.0.0.

API tested with CURL, and Home Assistant.